### PR TITLE
Update vitest extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,8 +4,8 @@
     "dbaeumer.vscode-eslint",
     "zxh404.vscode-proto3",
     "ms-vscode.hexeditor",
-    "zixuanchen.vitest-explorer",
     "mikestead.dotenv",
-    "bradlc.vscode-tailwindcss"
+    "bradlc.vscode-tailwindcss",
+    "vitest.explorer"
   ]
 }


### PR DESCRIPTION
This pull request updates the recommended extensions in the README file. The "vitest-explorer" extension has been replaced with the "vitest.explorer" extension. This change ensures that users have the most up-to-date and compatible extension for testing.